### PR TITLE
chore: swap pandas with polars in most places

### DIFF
--- a/docs/analysis-highlights.ipynb
+++ b/docs/analysis-highlights.ipynb
@@ -58,7 +58,7 @@
     "from pathlib import Path\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "import pandas as pd\n",
+    "import polars as pl\n",
     "from fastai.tabular.all import (\n",
     "    Categorify,\n",
     "    CategoryBlock,\n",
@@ -66,6 +66,7 @@
     "    TabularPandas,\n",
     "    tabular_learner,\n",
     ")\n",
+    "from functools import partial\n",
     "from rich import print as pprint\n",
     "\n",
     "import bundestag.data.download.huggingface as download_hf\n",
@@ -161,8 +162,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_parquet(path=file)\n",
-    "df.head(3).T"
+    "df = pl.read_parquet(file)\n",
+    "df.head(3)"
    ]
   },
   {
@@ -179,6 +180,15 @@
    "outputs": [],
    "source": [
     "party_votes = sim.get_votes_by_party(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "party_votes.head()"
    ]
   },
   {
@@ -237,10 +247,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mdb_vs_parties = sim.align_mdb_with_parties(mdb_votes, party_votes_pivoted).pipe(\n",
-    "    sim.compute_similarity, lsuffix=\"mdb\", rsuffix=\"party\"\n",
-    ")\n",
-    "mdb_vs_parties.head(3).T"
+    "mdb_and_parties = sim.align_mdb_with_parties(mdb_votes, party_votes_pivoted)\n",
+    "mdb_and_parties.head()"
    ]
   },
   {
@@ -249,7 +257,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mdb_vs_parties[\"Fraktion/Gruppe\"].value_counts()"
+    "mdb_vs_parties = sim.compute_similarity(mdb_and_parties, \"_party\")\n",
+    "mdb_vs_parties.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mdb_vs_parties[\"Fraktion/Gruppe_party\"].value_counts()"
    ]
   },
   {
@@ -257,24 +275,6 @@
    "metadata": {},
    "source": [
     "Plotting"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mdb_vs_parties[\"Fraktion/Gruppe\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mdb_vs_parties.index = pd.Index(range(len(mdb_vs_parties)))"
    ]
   },
   {
@@ -323,12 +323,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "party_votes_pivoted.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "party = \"SPD\"\n",
-    "partyA_vs_rest = sim.align_party_with_all_parties(party_votes_pivoted, party).pipe(\n",
-    "    sim.compute_similarity, lsuffix=\"a\", rsuffix=\"b\"\n",
-    ")\n",
+    "partyA_vs_rest = sim.align_party_with_all_parties(party_votes_pivoted, party)\n",
+    "partyA_vs_rest.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partyA_vs_rest = sim.compute_similarity(partyA_vs_rest, suffix=\"_b\")\n",
     "\n",
-    "partyA_vs_rest.head(3).T"
+    "partyA_vs_rest.head(3)"
    ]
   },
   {
@@ -443,7 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_polls = pd.read_parquet(path=file)"
+    "df_polls = pl.read_parquet(file)"
    ]
   },
   {
@@ -463,23 +480,78 @@
     "nlp_col = f\"{source_col}_nlp_processed\"\n",
     "num_topics = 5  # number of topics / clusters to identify\n",
     "\n",
-    "st = pc.SpacyTransformer()\n",
-    "\n",
+    "st = pc.SpacyTransformer()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_polls.head()[source_col].map_elements(\n",
+    "    partial(pc.clean_text, nlp=st.nlp), return_dtype=pl.List(pl.String)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# load data and prepare text for modelling\n",
-    "df_polls_lda = df_polls.copy().assign(\n",
-    "    **{nlp_col: lambda x: pc.clean_text(x, col=source_col, nlp=st.nlp)}\n",
+    "df_polls_lda = df_polls.with_columns(\n",
+    "    **{\n",
+    "        nlp_col: pl.col(source_col).map_elements(\n",
+    "            partial(pc.clean_text, nlp=st.nlp), return_dtype=pl.List(pl.String)\n",
+    "        )\n",
+    "    }\n",
     ")\n",
-    "\n",
+    "df_polls_lda.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# modelling clusters\n",
-    "st.fit_lda(df_polls_lda[nlp_col].values.tolist(), num_topics=num_topics)\n",
-    "\n",
+    "st.fit_lda(df_polls_lda[nlp_col].to_list(), num_topics=num_topics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# creating text features using fitted model\n",
-    "df_polls_lda, nlp_feature_cols = df_polls_lda.pipe(\n",
-    "    st.transform, col=nlp_col, return_new_cols=True\n",
+    "df_polls_lda, nlp_feature_cols = st.transform(\n",
+    "    df_polls_lda, col=nlp_col, return_new_cols=True\n",
     ")\n",
     "\n",
     "# inspecting clusters\n",
-    "display(df_polls_lda.head(3).T)"
+    "display(df_polls_lda.head(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st.lda_topics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nlp_feature_cols"
    ]
   },
   {
@@ -511,7 +583,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_all_votes = pd.read_parquet(path=path / f\"votes_{legislature_id}.parquet\")"
+    "df_all_votes = pl.read_parquet(path / f\"votes_{legislature_id}.parquet\")"
    ]
   },
   {
@@ -520,7 +592,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_mandates = pd.read_parquet(path=path / f\"mandates_{legislature_id}.parquet\")"
+    "df_mandates = pl.read_parquet(path / f\"mandates_{legislature_id}.parquet\")"
    ]
   },
   {
@@ -537,6 +609,15 @@
    "outputs": [],
    "source": [
     "splits = RandomSplitter(valid_pct=0.2)(df_all_votes)\n",
+    "splits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "y_col = \"vote\""
    ]
   },
@@ -563,7 +644,7 @@
    "outputs": [],
    "source": [
     "to = TabularPandas(\n",
-    "    df_all_votes,\n",
+    "    df_all_votes.to_pandas(),\n",
     "    cat_names=[\n",
     "        \"politician name\",\n",
     "        \"poll_id\",\n",
@@ -611,6 +692,24 @@
    "metadata": {},
    "source": [
     "Inspecting the predictions of the neural net over the validation set. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_mandates.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all_votes.head()"
    ]
   },
   {
@@ -674,8 +773,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "embeddings_pl = {\n",
+    "    \"politician name\": pl.DataFrame(\n",
+    "        {\n",
+    "            \"politician name__emb_component_0\": embeddings[\"politician name\"][\n",
+    "                \"politician name__emb_component_0\"\n",
+    "            ],\n",
+    "            \"politician name__emb_component_1\": embeddings[\"politician name\"][\n",
+    "                \"politician name__emb_component_1\"\n",
+    "            ],\n",
+    "            \"politician name\": embeddings[\"politician name\"][\"politician name\"],\n",
+    "        }\n",
+    "    ),\n",
+    "    \"poll_id\": pl.DataFrame(\n",
+    "        {\n",
+    "            \"poll_id__emb_component_0\": embeddings[\"poll_id\"][\n",
+    "                \"poll_id__emb_component_0\"\n",
+    "            ].values[1:],\n",
+    "            \"poll_id__emb_component_1\": embeddings[\"poll_id\"][\n",
+    "                \"poll_id__emb_component_1\"\n",
+    "            ].values[1:],\n",
+    "            \"poll_id\": [int(v) for v in embeddings[\"poll_id\"][\"poll_id\"].values[1:]],\n",
+    "        }\n",
+    "    ),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig = vp.plot_poll_embeddings(\n",
-    "    df_all_votes, df_polls, embeddings, df_mandates=df_mandates\n",
+    "    df_all_votes, df_polls, embeddings_pl, df_mandates=df_mandates\n",
     ")\n",
     "fig.show()\n",
     "if makedocs:\n",
@@ -703,7 +834,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = vp.plot_politician_embeddings(df_all_votes, df_mandates, embeddings)\n",
+    "fig = vp.plot_politician_embeddings(df_all_votes, df_mandates, embeddings_pl)\n",
     "fig.show()\n",
     "if makedocs:\n",
     "    fig.write_image(_fig_path / \"mandate_embeddings.png\")"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ build-backend = "hatchling.build"
 data = [
     "beautifulsoup4>=4.12.2",
     "fastcore>=1.5.29",
+    "fastexcel>=0.14.0",
     "fastparquet>=2023.2.0",
     "frictionless>=5.11.1",
     "ipywidgets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ data = [
     "seaborn>=0.12.2",
     "typer[all]>=0.7.0",
     "xlrd>=2.0.1",
+    "xlsxwriter>=3.2.5",
 ]
 gui = [
     "ipywidgets>=8.0.6",

--- a/src/bundestag/data/transform/abgeordnetenwatch/helper.py
+++ b/src/bundestag/data/transform/abgeordnetenwatch/helper.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-import pandas as pd
+import polars as pl
 
 logger = logging.getLogger(__name__)
 
@@ -20,17 +20,8 @@ def extract_party_from_string(s: str) -> str:
         return s
 
 
-def get_parties_from_col(
-    row: pd.Series, col="fraction_names", missing: str = "unknown"
-):
-    strings = row[col]
-    if strings is None or not isinstance(strings, list):
-        return [missing]
+def get_parties_from_col(elements: pl.Series, missing: str = "unknown") -> pl.Series:
+    if len(elements) > 0:
+        return elements.map_elements(extract_party_from_string)
     else:
-        return [extract_party_from_string(s) for s in strings]
-
-
-def get_politician_names(df: pd.DataFrame, col: str = "mandate"):
-    names = df[col].str.split(" ").str[:-4].str.join(" ")
-    logger.debug(f"Parsing `{col}` to names. Found {names.nunique()} names")
-    return names
+        return pl.Series([missing])

--- a/src/bundestag/data/transform/abgeordnetenwatch/process/mandates.py
+++ b/src/bundestag/data/transform/abgeordnetenwatch/process/mandates.py
@@ -2,7 +2,7 @@ import json
 import logging
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 
 import bundestag.schemas as schemas
 from bundestag.data.utils import get_location, get_mandates_filename
@@ -65,9 +65,9 @@ def parse_mandate_data(mandate: schemas.Mandate, missing: str = "unknown") -> di
     return d
 
 
-def get_mandates_data(legislature_id: int, path: Path) -> pd.DataFrame:
+def get_mandates_data(legislature_id: int, path: Path) -> pl.DataFrame:
     "Parses info from mandate json file(s) for `legislature_id`"
     info = load_mandate_json(legislature_id, path=path)
     mandates = schemas.MandatesResponse(**info)
-    df = pd.DataFrame([parse_mandate_data(m) for m in mandates.data])
+    df = pl.DataFrame([parse_mandate_data(m) for m in mandates.data])
     return df

--- a/src/bundestag/data/transform/abgeordnetenwatch/process/polls.py
+++ b/src/bundestag/data/transform/abgeordnetenwatch/process/polls.py
@@ -2,7 +2,7 @@ import json
 import logging
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 from bs4 import BeautifulSoup
 
 import bundestag.schemas as schemas
@@ -40,8 +40,9 @@ def parse_poll_data(poll: schemas.Poll) -> dict:
     return d
 
 
-def get_polls_data(legislature_id: int, path: Path) -> pd.DataFrame:
+def get_polls_data(legislature_id: int, path: Path) -> pl.DataFrame:
     "Parses info from poll json files for `legislature_id`"
     info = load_polls_json(legislature_id, path=path)
     polls = schemas.PollResponse(**info)
-    return pd.DataFrame([parse_poll_data(v) for v in polls.data])
+    df = pl.DataFrame([parse_poll_data(v) for v in polls.data])
+    return df

--- a/src/bundestag/data/transform/abgeordnetenwatch/transform.py
+++ b/src/bundestag/data/transform/abgeordnetenwatch/transform.py
@@ -73,7 +73,7 @@ def run(
     if not dry:
         file = get_polls_parquet_path(legislature_id, preprocessed_path)
         logger.info(f"writing to {file}")
-        df.to_parquet(path=file)
+        df.write_parquet(file)
 
     # mandates
     df = get_mandates_data(legislature_id, path=raw_path)

--- a/src/bundestag/data/transform/bundestag_sheets.py
+++ b/src/bundestag/data/transform/bundestag_sheets.py
@@ -4,8 +4,7 @@ import logging
 from pathlib import Path
 
 import pandas as pd
-
-# import polars as pl
+import polars as pl
 import tqdm
 import xlrd
 
@@ -66,35 +65,47 @@ def is_date(s: str, dayfirst: bool) -> bool:
 class ExcelReadException(Exception): ...
 
 
-def read_excel(file: Path) -> pd.DataFrame:
+def read_excel(file: Path) -> pl.DataFrame:
     try:
-        dfs = pd.read_excel(file, sheet_name=None, engine="openpyxl")
+        dfs = pl.read_excel(file, sheet_name=None, engine="openpyxl")
         # sanity check that there is only one sheet
-        if len(dfs) > 1:
-            raise ValueError(f"{file=} has more than one page, that's unexpected.")
-        sheet_name, df = next(iter(dfs.items()))
-        df["sheet_name"] = sheet_name
+        if isinstance(dfs, dict):
+            if len(dfs) > 1:
+                raise ValueError(f"{file=} has more than one page, that's unexpected.")
+
+            sheet_name, df = next(iter(dfs.items()))
+            df = df.with_columns(**{"sheet_name": pl.lit(sheet_name)})
+
+        else:
+            df = dfs.with_columns(**{"sheet_name": pl.lit("")})
+
     except:
         try:
             df = pd.read_excel(file, engine="xlrd")
-            df["sheet_name"] = ""
+
         except xlrd.biffh.XLRDError:
             raise ExcelReadException(f"Failed to parse {file}.")
+
+        df = pl.from_pandas(df)
+        df = df.with_columns(**{"sheet_name": pl.lit("")})
     return df
 
 
-def verify_vote_columns(sheet_file: Path, df: pd.DataFrame):
+def verify_vote_columns(sheet_file: Path, df: pl.DataFrame):
     "verifying that all vote columns (ja, nein, Enthaltung, ungültig, nichtabgegeben) are plausible"
-    mask = df.loc[:, VOTE_COLS].sum(axis=1) != 1
-    if mask.any():
-        msg = f"{sheet_file=} has rows with more than one vote:\n{df.loc[mask, :]}"
+    tmp = df.with_columns(
+        **{"hits": df.select(VOTE_COLS).sum_horizontal()}
+    ).with_columns(**{"implausible": pl.col("hits").ne(pl.lit(1))})
+
+    if tmp["implausible"].any():
+        msg = f"{sheet_file=} has rows with more than one vote:\n{tmp.filter(pl.col('implausible'))}"
         logger.error(msg)
         raise ValueError(msg)
 
 
 def handle_title_and_date(
     full_title: str, sheet_file: Path
-) -> tuple[str, pd.Timestamp | None]:
+) -> tuple[str, datetime.date | None]:
     "Extracting the title of the roll call vote and the date from full_title, if possible, otherwise fall back to sheet_file."
 
     # get date from full_title
@@ -108,32 +119,19 @@ def handle_title_and_date(
     fname_has_date = is_date(date_in_fname, dayfirst=False)
 
     if title_has_date:
-        date = pd.to_datetime(date_in_title, dayfirst=True)
+        date, _ = parse_date(date_in_title, dayfirst=True)
         title = ":".join(title[1:]).strip()
         return title, date
     elif fname_has_date:
-        date = pd.to_datetime(date_in_fname, dayfirst=False)
+        date, _ = parse_date(date_in_fname, dayfirst=False)
         return title_clean, date
     else:
         return title_clean, None
 
-    # if is_date(date_in_title, True):
-    #     date_in_title = pd.to_datetime(date_in_title, dayfirst=True)
-    #     title = ":".join(title[1:])
-    # elif is_date(date_in_fname, False):
-    #     date = pd.to_datetime(sheet_file.name.split("_")[0])
-    #     title = title_clean
-    # else:
-    #     date = None
-    #     title = title_clean
-
-    # title = title.strip()
-    return title, date
-
 
 def assign_date_and_title_columns(
-    sheet_file: Path, df: pd.DataFrame, file_title_maps: dict[str, str] | None = None
-) -> pd.DataFrame:
+    sheet_file: Path, df: pl.DataFrame, file_title_maps: dict[str, str] | None = None
+) -> pl.DataFrame:
     if file_title_maps is not None and sheet_file.name in file_title_maps:
         title, date = handle_title_and_date(
             file_title_maps[sheet_file.name], sheet_file
@@ -141,8 +139,13 @@ def assign_date_and_title_columns(
     else:
         title, date = None, None
 
-    df["date"] = date
-    df["title"] = title
+    df = df.with_columns(
+        **{
+            "date": pl.lit(date),
+            "title": pl.lit(title),
+        }
+    )
+
     return df
 
 
@@ -155,19 +158,25 @@ PARTY_MAP = {
 
 
 def disambiguate_party(
-    df: pd.DataFrame, col: str = "Fraktion/Gruppe", party_map: dict | None = None
-) -> pd.DataFrame:
+    df: pl.DataFrame, col: str = "Fraktion/Gruppe", party_map: dict | None = None
+) -> pl.DataFrame:
     if party_map is None:
         party_map = PARTY_MAP
-    df[col] = df[col].apply(lambda x: x if x not in party_map else party_map[x])
+    df = df.with_columns(
+        **{
+            col: pl.col(col).map_elements(
+                lambda x: x if x not in party_map else party_map[x]
+            )
+        }
+    )
+    # df[col] = df[col].apply(lambda x: x if x not in party_map else party_map[x])
     return df
 
 
 def get_sheet_df(
     sheet_file: str | Path,
     file_title_maps: dict[str, str] | None = None,
-    validate: bool = False,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     "Parsing xlsx and xls files into dataframes"
 
     sheet_file = Path(sheet_file)
@@ -178,78 +187,77 @@ def get_sheet_df(
 
     df = assign_date_and_title_columns(sheet_file, df, file_title_maps)
 
-    df = df.pipe(disambiguate_party)
+    df = disambiguate_party(df)
 
-    if validate:
-        schemas.SHEET.validate(df)
+    df = pl.DataFrame(df, schema=schemas.SHEET_PL)
 
     return df
 
 
 def get_squished_dataframe(
-    df: pd.DataFrame,
+    df: pl.DataFrame,
     id_col: str = "Bezeichnung",
     feature_cols: list[str] = VOTE_COLS,
     other_cols: list | None = None,
     validate: bool = False,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     "Reformats `df` by squishing the vote columns (ja, nein, Enthaltung, ...) into one column"
 
     other_cols = ["date", "title"] if other_cols is None else other_cols
-    df_sub = df.loc[:, [id_col] + feature_cols + other_cols]
+    df_sub = df.select([id_col] + feature_cols + other_cols)
 
     # add issue column
-    mask_date_title_missing = df_sub["date"].isnull() | df_sub["title"].isnull()
+    df_sub = df_sub.with_columns(
+        **{
+            "date or title missing": pl.col("date").is_null()
+            | pl.col("title").is_null()
+        }
+    )
 
-    n_missing = mask_date_title_missing.sum()
+    n_missing = df_sub["date or title missing"].sum()
+
     if n_missing > 0:  # TODO: that this can happen is weird - error in processing?
         raise ValueError(
             f"Missing date and or title information for {n_missing:_} rows ({n_missing / len(df_sub):.2%}), did you provide file_title_maps upstream?"
         )
 
-    df_sub["issue"] = df_sub["date"].dt.date.apply(str) + " " + df["title"]
+    df_sub = df_sub.drop("date or title missing")
 
-    df_sub = df_sub.set_index([id_col, "issue"] + other_cols)
-    df_sub = (
-        df_sub[df_sub == 1]
-        .stack()
-        .reset_index()
-        .drop(labels=0, axis=1)
-        .rename(columns={f"level_{2 + len(other_cols)}": "vote"})
+    df_sub = df_sub.with_columns(
+        **{"issue": pl.col("date").dt.date().cast(pl.String) + " " + pl.col("title")}
     )
-    df = df.join(
-        df_sub.set_index(["Bezeichnung", "date", "title"]),
-        on=["Bezeichnung", "date", "title"],
-    ).drop(columns=VOTE_COLS)
 
-    if validate:
-        schemas.SHEET_FINAL(df)
+    df_sub = df_sub.with_columns(
+        **{
+            "vote": (
+                pl.when(pl.col("ja") == pl.lit(1))
+                .then(pl.lit("ja"))
+                .otherwise(
+                    pl.when(pl.col("nein") == pl.lit(1))
+                    .then(pl.lit("nein"))
+                    .otherwise(
+                        pl.when(pl.col("Enthaltung") == pl.lit(1))
+                        .then(pl.lit("Enthaltung"))
+                        .otherwise(
+                            pl.when(pl.col("ungültig") == pl.lit(1))
+                            .then(pl.lit("ungültig"))
+                            .otherwise(
+                                pl.when(pl.col("nichtabgegeben") == pl.lit(1))
+                                .then(pl.lit("nichtabgegeben"))
+                                .otherwise(pl.lit("error"))
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    )
 
-    return df
+    df = df.drop(VOTE_COLS).join(
+        df_sub.drop(VOTE_COLS), on=["Bezeichnung", "date", "title"]
+    )
+    df = pl.DataFrame(df, schema=schemas.SHEET_FINAL_PL)
 
-
-DTYPES = {
-    "Wahlperiode": int,
-    "Sitzungnr": int,
-    "Abstimmnr": int,
-    "Fraktion/Gruppe": str,
-    "Name": str,
-    "Vorname": str,
-    "Titel": str,
-    "vote": str,
-    "issue": str,
-    #           'ja': bool, 'nein': bool, 'Enthaltung': bool, 'ungültig': bool, 'nichtabgegeben': bool, 'Bemerkung': str,
-    "Bezeichnung": str,
-    "sheet_name": str,
-    "date": "datetime64[ns]",
-    "title": str,
-}
-
-
-def set_sheet_dtypes(df: pd.DataFrame, dtypes: dict[str, str | object] | None = None):
-    dtypes = DTYPES if dtypes is None else dtypes
-    for col, dtype in dtypes.items():
-        df[col] = df[col].astype(dtype)  # type: ignore
     return df
 
 
@@ -257,7 +265,7 @@ def get_multiple_sheets_df(
     sheet_files: list[Path],
     file_title_maps: dict[str, str],
     validate: bool = False,
-):
+) -> pl.DataFrame:
     "Loads, processes and concatenates multiple vote sheets"
     logger.info("Loading processing and concatenating multiple vote sheets")
     df = []
@@ -270,9 +278,7 @@ def get_multiple_sheets_df(
         if sheet_file.name not in file_title_maps:
             continue
         try:
-            sheet_df = get_sheet_df(
-                sheet_file, file_title_maps=file_title_maps, validate=validate
-            )
+            sheet_df = get_sheet_df(sheet_file, file_title_maps=file_title_maps)
         except ExcelReadException:
             n_errors += 1
             continue
@@ -281,7 +287,6 @@ def get_multiple_sheets_df(
             sheet_df = get_squished_dataframe(sheet_df, validate=validate)
         except ValueError as ex:
             raise ValueError(f"Parsing failed for {sheet_file} with ValueError: {ex}")
-        sheet_df = set_sheet_dtypes(sheet_df)
 
         df.append(sheet_df)
 
@@ -292,7 +297,7 @@ def get_multiple_sheets_df(
         logger.warning(
             f"{n_errors:_} / {n:_} = {n_errors / n:.2%} % files skipped due to some excel parsing error, likely xls files."
         )
-    return pd.concat(df, ignore_index=True)
+    return pl.concat(df)
 
 
 def get_sheet_uris_from_json(source: Source, json_path: Path) -> dict[str, str]:
@@ -350,6 +355,6 @@ def run(
     if not dry:
         path = preprocessed_path / "bundestag.de_votes.parquet"
         logger.info(f"Writing to {path}")
-        df.to_parquet(path)
+        df.write_parquet(path)
 
     logger.info("Done parsing sheets")

--- a/src/bundestag/schemas.py
+++ b/src/bundestag/schemas.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
+import polars as pl
 from pandera.pandas import Check, Column, DataFrameSchema, Index
 from pydantic import BaseModel
 
@@ -710,4 +711,44 @@ SHEET_FINAL = DataFrameSchema(
     unique_column_names=False,
     title=None,
     description=None,
+)
+SHEET_PL = pl.Schema(
+    {
+        "Wahlperiode": pl.Int64(),
+        "Sitzungnr": pl.Int64(),
+        "Abstimmnr": pl.Int64(),
+        "Fraktion/Gruppe": pl.String(),
+        "Name": pl.String(),
+        "Vorname": pl.String(),
+        "Titel": pl.String(),
+        "ja": pl.Int64(),
+        "nein": pl.Int64(),
+        "Enthaltung": pl.Int64(),
+        "ungültig": pl.Int64(),
+        "nichtabgegeben": pl.Int64(),
+        "Bezeichnung": pl.String(),
+        "Bemerkung": pl.String(),
+        "sheet_name": pl.String(),
+        "date": pl.Datetime(time_unit="ns"),
+        "title": pl.String(),
+    }
+)
+
+SHEET_FINAL_PL = pl.Schema(
+    {
+        "Wahlperiode": pl.Int64(),
+        "Sitzungnr": pl.Int64(),
+        "Abstimmnr": pl.Int64(),
+        "Fraktion/Gruppe": pl.String(),
+        "Name": pl.String(),
+        "Vorname": pl.String(),
+        "Titel": pl.String(),
+        "Bezeichnung": pl.String(),
+        "Bemerkung": pl.String(),
+        "sheet_name": pl.String(),
+        "date": pl.Datetime(time_unit="ns"),
+        "title": pl.String(),
+        "issue": pl.String(),
+        "vote": pl.String(),
+    }
 )

--- a/tests/data/download/test_bundestag_sheets.py
+++ b/tests/data/download/test_bundestag_sheets.py
@@ -155,9 +155,6 @@ def test_run(tmp_path: Path):
 
     r = httpx.Response(200, json={"wuppety": 42})
 
-    # path_xlsx_uris = sheet_dir / "xlsx_uris.json"
-    # path_xlsx_uris.touch()
-
     with (
         patch("httpx.get", MagicMock(return_value=r)) as _get,
     ):

--- a/tests/data/transform/abgeordnetenwatch/test_helper.py
+++ b/tests/data/transform/abgeordnetenwatch/test_helper.py
@@ -1,12 +1,11 @@
 import typing as T
 
-import pandas as pd
+import polars as pl
 import pytest
 
 from bundestag.data.transform.abgeordnetenwatch.helper import (
     extract_party_from_string,
     get_parties_from_col,
-    get_politician_names,
 )
 
 
@@ -44,28 +43,7 @@ def test_extract_party_from_string(s: str, expected: str):
     ],
 )
 def test_get_parties_from_col(entries: T.List[str], targets: T.List[str]):
-    col = "fraction_names"
-    row = pd.Series({col: entries})
+    elements = pl.Series(entries)
     # line to test
-    res = get_parties_from_col(row, col=col, missing="unknown")
+    res = get_parties_from_col(elements, missing="unknown")
     assert all([targ == res[i] for i, targ in enumerate(targets)])
-
-
-def test_get_politician_names():
-    col = "mandate"
-    df = pd.DataFrame(
-        {
-            col: [
-                "Zeki Gökhan (Bundestag 2017 - 2021)",
-                "bla blaaaa blah (Bundestag 2017 - 2021)",
-                "wup (Bundestag 2022 - 2025)",
-            ]
-        }
-    )
-
-    # line to test
-    names = get_politician_names(df, col=col)
-
-    assert names[0] == "Zeki Gökhan"
-    assert names[1] == "bla blaaaa blah"
-    assert names[2] == "wup"

--- a/tests/data/transform/process/conftest.py
+++ b/tests/data/transform/process/conftest.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pandas as pd
+import polars as pl
 import pytest
 
 import bundestag.schemas as schemas
@@ -78,56 +79,56 @@ def POLLS_DF() -> pd.DataFrame:
 
 
 @pytest.fixture()
-def MANDATES_DF() -> pd.DataFrame:
-    return pd.DataFrame(
+def MANDATES_DF() -> pl.DataFrame:
+    return pl.DataFrame(
         {
-            "legislature_id": {0: 111, 1: 111},
-            "legislature_period": {
-                0: "Bundestag 2017 - 2021",
-                1: "Bundestag 2017 - 2021",
-            },
-            "mandate_id": {0: 52657, 1: 52107},
-            "mandate": {
-                0: "Zeki Gökhan (Bundestag 2017 - 2021)",
-                1: "Florian Jäger (Bundestag 2017 - 2021)",
-            },
-            "politician_id": {0: 122163, 1: 121214},
-            "politician": {0: "Zeki Gökhan", 1: "Florian Jäger"},
-            "politician_url": {
-                0: "https://www.abgeordnetenwatch.de/profile/zeki-goekhan",
-                1: "https://www.abgeordnetenwatch.de/profile/florian-jaeger",
-            },
-            "start_date": {0: "2021-08-19", 1: "2021-07-20"},
-            "end_date": {0: "", 1: ""},
-            "constituency_id": {0: 4215, 1: 4339},
-            "constituency_name": {
-                0: "91 - Rhein-Erft-Kreis I (Bundestag 2017 - 2021)",
-                1: "215 - Fürstenfeldbruck (Bundestag 2017 - 2021)",
-            },
-            "fraction_names": {
-                0: ["DIE LINKE seit 19.08.2021"],
-                1: ["AfD seit 20.07.2021"],
-            },
-            "fraction_ids": {0: [9233], 1: [9228]},
-            "fraction_starts": {0: ["2021-08-19"], 1: ["2021-07-20"]},
-            "fraction_ends": {0: [""], 1: [""]},
+            "legislature_id": [111, 111],
+            "legislature_period": [
+                "Bundestag 2017 - 2021",
+                "Bundestag 2017 - 2021",
+            ],
+            "mandate_id": [52657, 52107],
+            "mandate": [
+                "Zeki Gökhan (Bundestag 2017 - 2021)",
+                "Florian Jäger (Bundestag 2017 - 2021)",
+            ],
+            "politician_id": [122163, 121214],
+            "politician": ["Zeki Gökhan", "Florian Jäger"],
+            "politician_url": [
+                "https://www.abgeordnetenwatch.de/profile/zeki-goekhan",
+                "https://www.abgeordnetenwatch.de/profile/florian-jaeger",
+            ],
+            "start_date": ["2021-08-19", "2021-07-20"],
+            "end_date": ["", ""],
+            "constituency_id": [4215, 4339],
+            "constituency_name": [
+                "91 - Rhein-Erft-Kreis I (Bundestag 2017 - 2021)",
+                "215 - Fürstenfeldbruck (Bundestag 2017 - 2021)",
+            ],
+            "fraction_names": [
+                ["DIE LINKE seit 19.08.2021"],
+                ["AfD seit 20.07.2021"],
+            ],
+            "fraction_ids": [[9233], [9228]],
+            "fraction_starts": [["2021-08-19"], ["2021-07-20"]],
+            "fraction_ends": [[""], [""]],
         }
     )
 
 
 @pytest.fixture()
-def VOTES_DF() -> pd.DataFrame:
-    return pd.DataFrame(
+def VOTES_DF() -> pl.DataFrame:
+    return pl.DataFrame(
         {
-            "mandate_id": {0: 45467, 1: 44472},
-            "mandate": {
-                0: "Michael von Abercron (Bundestag 2017 - 2021)",
-                1: "Stephan Albani (Bundestag 2017 - 2021)",
-            },
-            "poll_id": {0: 4217, 1: 4217},
-            "vote": {0: "yes", 1: "yes"},
-            "reason_no_show": {0: None, 1: None},
-            "reason_no_show_other": {0: None, 1: None},
+            "mandate_id": [45467, 44472],
+            "mandate": [
+                "Michael von Abercron (Bundestag 2017 - 2021)",
+                "Stephan Albani (Bundestag 2017 - 2021)",
+            ],
+            "poll_id": [4217, 4217],
+            "vote": ["yes", "yes"],
+            "reason_no_show": [None, None],
+            "reason_no_show_other": [None, None],
         }
     )
 

--- a/tests/data/transform/process/conftest.py
+++ b/tests/data/transform/process/conftest.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-import pandas as pd
 import polars as pl
 import pytest
 
@@ -52,28 +51,28 @@ def sample_votes_response(sample_vote_json_path: Path) -> schemas.VoteResponse:
 
 
 @pytest.fixture()
-def POLLS_DF() -> pd.DataFrame:
-    return pd.DataFrame(
+def POLLS_DF() -> pl.DataFrame:
+    return pl.DataFrame(
         {
-            "poll_id": {0: 4293, 1: 4284},
-            "poll_title": {
-                0: "Änderung des Infektionsschutzgesetzes und Grundrechtseinschränkungen",
-                1: "Fortbestand der epidemischen Lage von nationaler Tragweite",
-            },
-            "poll_first_committee": {
-                0: "Haushaltsausschuss",
-                1: "Ausschuss für Gesundheit",
-            },
-            "poll_description": {
-                0: "Ein von den Fraktionen der CDU/CSU und SPD eingebrachter Gesetzentwurf zur Hilfe für Flutopfer in Deutschland sieht auch Änderungen des Infektionsschutzgesetzes vor. Diese sollen unter anderem in bestimmten Einrichtungen eine Auskunftspflicht von Mitarbeiter:innen zu ihrem Impf- oder Genesenenstatus ermöglichen.\nIm Vorfeld hatte die Opposition für das Gesetzespaket eine namentliche Abstimmung nur über die Punkte verlangt, die auch das Infektionsschutzgesetz betreffen.\nDie Neuregelungen wurden mit 344 Ja-Stimmen der Unions- und SPD-Fraktion gegen 280 Nein-Stimmen der Oppositionsfraktionen sowie einzelner Abgeordneter der Union und SPD angenommen. Lediglich eine Abgeordnete hatte sich bei der Abstimmung enthalten.",
-                1: "Der von den Fraktionen der CDU/CSU und SPD eingebrachte Antrag sieht vor, dass der Bundestag feststellt, dass die seit dem 25. März 2020 geltende epidemische Lage von nationaler Tragweite weiter fortbesteht. Das wird damit begründet, dass angesichts des erneuten Anstiegs der COVID-19-Fallzahlen in Deutschland weiterhin eine erhebliche Gesundheitsgefährdung der Bevölkerung gegeben sei.\nDer Antrag wurde mit 325 Ja-Stimmen der CDU- und SPD-Fraktion gegen 252 Nein-Stimmen der Oppositionsfraktionen angenommen. Fünf Abgeordnete haben sich enthalten.",
-            },
-            "legislature_id": {0: 111, 1: 111},
-            "legislature_period": {
-                0: "Bundestag 2017 - 2021",
-                1: "Bundestag 2017 - 2021",
-            },
-            "poll_date": {0: "2021-09-07", 1: "2021-08-25"},
+            "poll_id": [4293, 4284],
+            "poll_title": [
+                "Änderung des Infektionsschutzgesetzes und Grundrechtseinschränkungen",
+                "Fortbestand der epidemischen Lage von nationaler Tragweite",
+            ],
+            "poll_first_committee": [
+                "Haushaltsausschuss",
+                "Ausschuss für Gesundheit",
+            ],
+            "poll_description": [
+                "Ein von den Fraktionen der CDU/CSU und SPD eingebrachter Gesetzentwurf zur Hilfe für Flutopfer in Deutschland sieht auch Änderungen des Infektionsschutzgesetzes vor. Diese sollen unter anderem in bestimmten Einrichtungen eine Auskunftspflicht von Mitarbeiter:innen zu ihrem Impf- oder Genesenenstatus ermöglichen.\nIm Vorfeld hatte die Opposition für das Gesetzespaket eine namentliche Abstimmung nur über die Punkte verlangt, die auch das Infektionsschutzgesetz betreffen.\nDie Neuregelungen wurden mit 344 Ja-Stimmen der Unions- und SPD-Fraktion gegen 280 Nein-Stimmen der Oppositionsfraktionen sowie einzelner Abgeordneter der Union und SPD angenommen. Lediglich eine Abgeordnete hatte sich bei der Abstimmung enthalten.",
+                "Der von den Fraktionen der CDU/CSU und SPD eingebrachte Antrag sieht vor, dass der Bundestag feststellt, dass die seit dem 25. März 2020 geltende epidemische Lage von nationaler Tragweite weiter fortbesteht. Das wird damit begründet, dass angesichts des erneuten Anstiegs der COVID-19-Fallzahlen in Deutschland weiterhin eine erhebliche Gesundheitsgefährdung der Bevölkerung gegeben sei.\nDer Antrag wurde mit 325 Ja-Stimmen der CDU- und SPD-Fraktion gegen 252 Nein-Stimmen der Oppositionsfraktionen angenommen. Fünf Abgeordnete haben sich enthalten.",
+            ],
+            "legislature_id": [111, 111],
+            "legislature_period": [
+                "Bundestag 2017 - 2021",
+                "Bundestag 2017 - 2021",
+            ],
+            "poll_date": ["2021-09-07", "2021-08-25"],
         }
     )
 

--- a/tests/data/transform/process/test_mandates.py
+++ b/tests/data/transform/process/test_mandates.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 import pytest
 from inline_snapshot import snapshot
 
@@ -12,7 +12,7 @@ from bundestag.data.transform.abgeordnetenwatch.process.mandates import (
 )
 
 
-def test_get_mandates_data(sample_mandates_json_path: Path, MANDATES_DF: pd.DataFrame):
+def test_get_mandates_data(sample_mandates_json_path: Path, MANDATES_DF: pl.DataFrame):
     legislature_id = 111
     res = get_mandates_data(legislature_id, sample_mandates_json_path.parent)
     assert res.equals(MANDATES_DF)

--- a/tests/data/transform/process/test_polls.py
+++ b/tests/data/transform/process/test_polls.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 import pytest
 from inline_snapshot import snapshot
 
@@ -14,13 +14,13 @@ from bundestag.data.transform.abgeordnetenwatch.process.polls import (
 # =================== get_polls_data ===================
 
 
-def test_get_polls_data(sample_poll_json_path: Path, POLLS_DF: pd.DataFrame):
+def test_get_polls_data(sample_poll_json_path: Path, POLLS_DF: pl.DataFrame):
     """Tests getting polls data and parsing it into a DataFrame."""
     legislature_id = 111
 
     df = get_polls_data(legislature_id, sample_poll_json_path.parent)
 
-    assert isinstance(df, pd.DataFrame)
+    assert isinstance(df, pl.DataFrame)
     assert df.equals(POLLS_DF)
 
 
@@ -50,7 +50,7 @@ def test_get_polls_data_empty(tmp_path: Path):
 
     # Create a dummy file
     file_path = tmp_path / f"polls_legislature_{legislature_id}.json"
-    with open(file_path, "w") as f:
+    with file_path.open("w") as f:
         try:
             # pydantic v2
             f.write(poll_response_data.model_dump_json())
@@ -61,7 +61,7 @@ def test_get_polls_data_empty(tmp_path: Path):
     # Test getting the data
     df = get_polls_data(legislature_id, path=tmp_path)
 
-    assert isinstance(df, pd.DataFrame)
+    assert isinstance(df, pl.DataFrame)
     assert len(df) == 0
 
 

--- a/tests/data/transform/process/test_votes.py
+++ b/tests/data/transform/process/test_votes.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 import pytest
 from inline_snapshot import snapshot
 
@@ -13,7 +13,7 @@ from bundestag.data.transform.abgeordnetenwatch.process.votes import (
 )
 
 
-def test_get_votes_data(sample_vote_json_path: Path, VOTES_DF: pd.DataFrame):
+def test_get_votes_data(sample_vote_json_path: Path, VOTES_DF: pl.DataFrame):
     legislature_id = 111
     poll_id = 4217
     res = get_votes_data(legislature_id, poll_id, sample_vote_json_path.parent.parent)
@@ -177,7 +177,7 @@ def test_load_vote_json(sample_vote_json_path: Path):
 
 @pytest.mark.parametrize("validate", [True, False])
 def test_compile_votes_data(
-    sample_vote_json_path: Path, VOTES_DF: pd.DataFrame, validate: bool
+    sample_vote_json_path: Path, VOTES_DF: pl.DataFrame, validate: bool
 ):
     legislature_id = 111
 

--- a/tests/test_vote_prediction.py
+++ b/tests/test_vote_prediction.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import plotly.graph_objects as go
+import polars as pl
 import pytest
 from fastai.tabular.all import (
     TabularLearner,
@@ -19,7 +20,7 @@ from bundestag.vote_prediction import (
 @pytest.mark.parametrize("seed,shuffle", [(None, True), (42, False)])
 def test_poll_splitter(seed: int, shuffle: bool):
     c = "poll"
-    df = pd.DataFrame(
+    df = pl.DataFrame(
         {
             c: list(range(10)),
         }
@@ -62,13 +63,12 @@ def test_get_embeddings(transform: str | None, learn: TabularLearner):
     assert all([k in emb for k in learn.dls.classes])
 
 
-def test_get_poll_proponents(df_all_votes: pd.DataFrame, df_mandates: pd.DataFrame):
+def test_get_poll_proponents(df_all_votes: pl.DataFrame, df_mandates: pl.DataFrame):
     proponents = get_poll_proponents(df_all_votes, df_mandates)
 
-    assert proponents.index.nunique() == len(proponents)
-    exp_cols = ["strongest proponent", "yesses", "total", "yes %"]
+    exp_cols = ["strongest proponent", "yesses", "total", "yes %", "poll_id"]
     assert all([c in proponents.columns for c in exp_cols])
-    assert proponents.index.name == "poll_id"
+    assert proponents["poll_id"].n_unique() == len(proponents)
     assert proponents["yes %"].max() <= 100
     assert proponents["yes %"].min() >= 0
     assert proponents["total"].min() >= 0
@@ -79,9 +79,9 @@ def test_get_poll_proponents(df_all_votes: pd.DataFrame, df_mandates: pd.DataFra
 @pytest.mark.skip("skipping plot")
 def test_plot_predictions(
     learn: TabularLearner,
-    df_all_votes: pd.DataFrame,
-    df_mandates: pd.DataFrame,
-    df_polls: pd.DataFrame,
+    df_all_votes: pl.DataFrame,
+    df_mandates: pl.DataFrame,
+    df_polls: pl.DataFrame,
     y_col: str,
     splits: tuple[list[int], list[int]],
 ):
@@ -91,9 +91,9 @@ def test_plot_predictions(
 @pytest.mark.skip("skipping plot")
 @pytest.mark.slow
 def test_plot_poll_embeddings(
-    df_all_votes: pd.DataFrame,
-    df_mandates: pd.DataFrame,
-    df_polls: pd.DataFrame,
+    df_all_votes: pl.DataFrame,
+    df_mandates: pl.DataFrame,
+    df_polls: pl.DataFrame,
     embeddings: dict,
 ):
     fig = plot_poll_embeddings(df_all_votes, df_polls, embeddings, df_mandates)
@@ -104,8 +104,8 @@ def test_plot_poll_embeddings(
 @pytest.mark.skip("skipping plot")
 @pytest.mark.slow
 def test_plot_politician_embeddings(
-    df_all_votes: pd.DataFrame,
-    df_mandates: pd.DataFrame,
+    df_all_votes: pl.DataFrame,
+    df_mandates: pl.DataFrame,
     embeddings: dict,
 ):
     fig = plot_politician_embeddings(

--- a/uv.lock
+++ b/uv.lock
@@ -287,6 +287,7 @@ binder = [
     { name = "spacy" },
     { name = "typer" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
 ]
 data = [
     { name = "beautifulsoup4" },
@@ -308,6 +309,7 @@ data = [
     { name = "seaborn" },
     { name = "typer" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
 ]
 database = [
     { name = "attrs" },
@@ -388,6 +390,7 @@ database = [
     { name = "validators" },
     { name = "wrapt" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
     { name = "zipp" },
 ]
 docs = [
@@ -417,6 +420,7 @@ docs = [
     { name = "spacy" },
     { name = "typer" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
 ]
 gui = [
     { name = "beautifulsoup4" },
@@ -438,6 +442,7 @@ gui = [
     { name = "seaborn" },
     { name = "typer" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
 ]
 ml = [
     { name = "beautifulsoup4" },
@@ -463,6 +468,7 @@ ml = [
     { name = "spacy" },
     { name = "typer" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
 ]
 style-and-test = [
     { name = "beautifulsoup4" },
@@ -494,6 +500,7 @@ style-and-test = [
     { name = "spacy" },
     { name = "typer" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
 ]
 
 [package.metadata]
@@ -525,6 +532,7 @@ binder = [
     { name = "spacy", specifier = ">=3.5.2" },
     { name = "typer", extras = ["all"], specifier = ">=0.7.0" },
     { name = "xlrd", specifier = ">=2.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.5" },
 ]
 data = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
@@ -546,6 +554,7 @@ data = [
     { name = "seaborn", specifier = ">=0.12.2" },
     { name = "typer", extras = ["all"], specifier = ">=0.7.0" },
     { name = "xlrd", specifier = ">=2.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.5" },
 ]
 database = [
     { name = "attrs", specifier = ">=23.1.0" },
@@ -626,6 +635,7 @@ database = [
     { name = "validators", specifier = ">=0.20.0" },
     { name = "wrapt", specifier = ">=1.15.0" },
     { name = "xlrd", specifier = ">=2.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.5" },
     { name = "zipp", specifier = ">=3.15.0" },
 ]
 docs = [
@@ -657,6 +667,7 @@ docs = [
     { name = "spacy", specifier = ">=3.5.2" },
     { name = "typer", extras = ["all"], specifier = ">=0.7.0" },
     { name = "xlrd", specifier = ">=2.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.5" },
 ]
 gui = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
@@ -680,6 +691,7 @@ gui = [
     { name = "seaborn", specifier = ">=0.12.2" },
     { name = "typer", extras = ["all"], specifier = ">=0.7.0" },
     { name = "xlrd", specifier = ">=2.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.5" },
 ]
 ml = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
@@ -705,6 +717,7 @@ ml = [
     { name = "spacy", specifier = ">=3.5.2" },
     { name = "typer", extras = ["all"], specifier = ">=0.7.0" },
     { name = "xlrd", specifier = ">=2.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.5" },
 ]
 style-and-test = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
@@ -738,6 +751,7 @@ style-and-test = [
     { name = "spacy", specifier = ">=3.5.2" },
     { name = "typer", extras = ["all"], specifier = ">=0.7.0" },
     { name = "xlrd", specifier = ">=2.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.5" },
 ]
 
 [[package]]
@@ -5753,6 +5767,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/47/7704bac42ac6fe1710ae099b70e6a1e68ed173ef14792b647808c357da43/xlsxwriter-3.2.5.tar.gz", hash = "sha256:7e88469d607cdc920151c0ab3ce9cf1a83992d4b7bc730c5ffdd1a12115a7dbe", size = 213306, upload-time = "2025-06-17T08:59:14.619Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/34/a22e6664211f0c8879521328000bdcae9bf6dbafa94a923e531f6d5b3f73/xlsxwriter-3.2.5-py3-none-any.whl", hash = "sha256:4f4824234e1eaf9d95df9a8fe974585ff91d0f5e3d3f12ace5b71e443c1c6abd", size = 172347, upload-time = "2025-06-17T08:59:13.453Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -267,6 +267,7 @@ binder = [
     { name = "beautifulsoup4" },
     { name = "fastai" },
     { name = "fastcore" },
+    { name = "fastexcel" },
     { name = "fastparquet" },
     { name = "frictionless" },
     { name = "gensim" },
@@ -290,6 +291,7 @@ binder = [
 data = [
     { name = "beautifulsoup4" },
     { name = "fastcore" },
+    { name = "fastexcel" },
     { name = "fastparquet" },
     { name = "frictionless" },
     { name = "ipywidgets" },
@@ -324,6 +326,7 @@ database = [
     { name = "decorator" },
     { name = "et-xmlfile" },
     { name = "fastcore" },
+    { name = "fastexcel" },
     { name = "fastparquet" },
     { name = "fonttools" },
     { name = "frictionless" },
@@ -391,6 +394,7 @@ docs = [
     { name = "beautifulsoup4" },
     { name = "fastai" },
     { name = "fastcore" },
+    { name = "fastexcel" },
     { name = "fastparquet" },
     { name = "frictionless" },
     { name = "gensim" },
@@ -417,6 +421,7 @@ docs = [
 gui = [
     { name = "beautifulsoup4" },
     { name = "fastcore" },
+    { name = "fastexcel" },
     { name = "fastparquet" },
     { name = "frictionless" },
     { name = "ipywidgets" },
@@ -438,6 +443,7 @@ ml = [
     { name = "beautifulsoup4" },
     { name = "fastai" },
     { name = "fastcore" },
+    { name = "fastexcel" },
     { name = "fastparquet" },
     { name = "frictionless" },
     { name = "gensim" },
@@ -464,6 +470,7 @@ style-and-test = [
     { name = "dirty-equals" },
     { name = "fastai" },
     { name = "fastcore" },
+    { name = "fastexcel" },
     { name = "fastparquet" },
     { name = "frictionless" },
     { name = "gensim" },
@@ -496,6 +503,7 @@ binder = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
     { name = "fastai", specifier = ">=2.7.12" },
     { name = "fastcore", specifier = ">=1.5.29" },
+    { name = "fastexcel", specifier = ">=0.14.0" },
     { name = "fastparquet", specifier = ">=2023.2.0" },
     { name = "frictionless", specifier = ">=5.11.1" },
     { name = "gensim", specifier = ">=4.3.1" },
@@ -521,6 +529,7 @@ binder = [
 data = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
     { name = "fastcore", specifier = ">=1.5.29" },
+    { name = "fastexcel", specifier = ">=0.14.0" },
     { name = "fastparquet", specifier = ">=2023.2.0" },
     { name = "frictionless", specifier = ">=5.11.1" },
     { name = "ipywidgets" },
@@ -554,6 +563,7 @@ database = [
     { name = "decorator", specifier = ">=5.1.1" },
     { name = "et-xmlfile", specifier = ">=1.1.0" },
     { name = "fastcore", specifier = ">=1.5.29" },
+    { name = "fastexcel", specifier = ">=0.14.0" },
     { name = "fastparquet", specifier = ">=2023.2.0" },
     { name = "fonttools", specifier = ">=4.39.3" },
     { name = "frictionless", specifier = ">=5.11.1" },
@@ -622,6 +632,7 @@ docs = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
     { name = "fastai", specifier = ">=2.7.12" },
     { name = "fastcore", specifier = ">=1.5.29" },
+    { name = "fastexcel", specifier = ">=0.14.0" },
     { name = "fastparquet", specifier = ">=2023.2.0" },
     { name = "frictionless", specifier = ">=5.11.1" },
     { name = "gensim", specifier = ">=4.3.1" },
@@ -650,6 +661,7 @@ docs = [
 gui = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
     { name = "fastcore", specifier = ">=1.5.29" },
+    { name = "fastexcel", specifier = ">=0.14.0" },
     { name = "fastparquet", specifier = ">=2023.2.0" },
     { name = "frictionless", specifier = ">=5.11.1" },
     { name = "ipywidgets" },
@@ -673,6 +685,7 @@ ml = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
     { name = "fastai", specifier = ">=2.7.12" },
     { name = "fastcore", specifier = ">=1.5.29" },
+    { name = "fastexcel", specifier = ">=0.14.0" },
     { name = "fastparquet", specifier = ">=2023.2.0" },
     { name = "frictionless", specifier = ">=5.11.1" },
     { name = "gensim", specifier = ">=4.3.1" },
@@ -699,6 +712,7 @@ style-and-test = [
     { name = "dirty-equals", specifier = ">=0.9.0" },
     { name = "fastai", specifier = ">=2.7.12" },
     { name = "fastcore", specifier = ">=1.5.29" },
+    { name = "fastexcel", specifier = ">=0.14.0" },
     { name = "fastparquet", specifier = ">=2023.2.0" },
     { name = "frictionless", specifier = ">=5.11.1" },
     { name = "gensim", specifier = ">=4.3.1" },
@@ -1589,6 +1603,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/be/d2c2e8dc81aa88316ed27f1bd707440a83a7420c35e67c0b143fe81aeca9/fastdownload-0.0.7.tar.gz", hash = "sha256:20507edb8e89406a1fbd7775e6e2a3d81a4dd633dd506b0e9cf0e1613e831d6a", size = 16096, upload-time = "2022-07-07T18:35:53.336Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/60/ed35253a05a70b63e4f52df1daa39a6a464a3e22b0bd060b77f63e2e2b6a/fastdownload-0.0.7-py3-none-any.whl", hash = "sha256:b791fa3406a2da003ba64615f03c60e2ea041c3c555796450b9a9a601bc0bbac", size = 12803, upload-time = "2022-07-07T18:35:50.912Z" },
+]
+
+[[package]]
+name = "fastexcel"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyarrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/55/376bc213921232d18dc9287c7e4eddd892d29e6a988c3ab022ee96f3a7ae/fastexcel-0.14.0.tar.gz", hash = "sha256:c73460c2ce2a07cf1a21a27aae67af3bc6a855fb4aa191c20c6ddae3f0573215", size = 40892, upload-time = "2025-04-30T08:57:05.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/5a/e5612bb03f113e283cdd4e137a24e60d312230e55870a2879cc62ee256cd/fastexcel-0.14.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8cf9fdff9df918cc2dfad66932cd238b6e1e5e1b7b0a079df713a35d2af1586e", size = 1281472, upload-time = "2025-04-30T08:57:00.658Z" },
+    { url = "https://files.pythonhosted.org/packages/12/97/204b0da0b1d94af752e5a7a515d4b68e8d957bc48a04d27a3087ea80e0c2/fastexcel-0.14.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:0764cb1232e5feb4a7953ee53e60a46f330fa32ef012d813fa491173c7578d3b", size = 1235392, upload-time = "2025-04-30T08:57:02.227Z" },
+    { url = "https://files.pythonhosted.org/packages/38/41/7a0b8c0421cbda0f6185bfeaf55d06cd12073f68abb31cc70f385350f1bc/fastexcel-0.14.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fecc5927ef18eba36f360aec0994e2cef106f8d83f197734d460ae198e5c0b87", size = 1359282, upload-time = "2025-04-30T08:56:57.271Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/86/f00dae040b315505008c4e94ae59c5de0b5fdaefdb27c046bb11917628da/fastexcel-0.14.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70f463b88d72205eb5069754b07edb9a877bab9991ca71f8db1cc4e1bb8d8a4", size = 1383225, upload-time = "2025-04-30T08:56:59.068Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5f/fdb54eab1fae9057fbcaca3b4b283cde717686c9e67e3cff2796a308b1e2/fastexcel-0.14.0-cp39-abi3-win_amd64.whl", hash = "sha256:856d061b254268302ee968d10fd446b83f4a1a932588149539be4fb9d34224d4", size = 1094572, upload-time = "2025-04-30T08:57:03.58Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request migrates the data processing and analysis codebase from using pandas to polars for improved performance and consistency. The changes affect data ingestion, transformation, and analysis scripts, as well as helper functions and documentation notebooks. Additionally, there are updates to dependencies to support the new data handling approach and some minor improvements to code structure and clarity.

**Migration from pandas to polars:**

* All imports and data operations in `.docker/ingest_data.py`, `src/bundestag/data/transform/abgeordnetenwatch/helper.py`, and transformation scripts (`mandates.py`, `polls.py`, `votes.py`) have been switched from pandas to polars, including reading/writing parquet files and database operations. [[1]](diffhunk://#diff-29e55893b5773fcc477d3cbcf2c45d45e8952b11ea45b2257d48a3c0d02c7e98L4-L7) [[2]](diffhunk://#diff-20fd3e4c369751890e8245aac2e410c6df04e68ead440877e209adb69458bc3fL4-R4) [[3]](diffhunk://#diff-38f666ce9ccc6027ff58223dc36c712a79f481eed42b420adb4d7d957df9b875L5-R5) [[4]](diffhunk://#diff-b200d6c69e1b94bb7f3dedbf2fb16dfe28e5a96eb203482841fccee2e0b52a95L5-R5) [[5]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L5-R5)
* DataFrames returned by transformation functions are now polars DataFrames, and method signatures have been updated accordingly. [[1]](diffhunk://#diff-38f666ce9ccc6027ff58223dc36c712a79f481eed42b420adb4d7d957df9b875L68-R72) [[2]](diffhunk://#diff-b200d6c69e1b94bb7f3dedbf2fb16dfe28e5a96eb203482841fccee2e0b52a95L43-R48) [[3]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L48-R48) [[4]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L63-R70)

**Refactoring and API changes in helper and transformation functions:**

* Helper functions for extracting parties and politician names have been rewritten to work with polars Series and DataFrames, improving performance and compatibility.
* Data transformation functions (e.g., for mandates, polls, votes) now consistently use polars DataFrames and methods. [[1]](diffhunk://#diff-38f666ce9ccc6027ff58223dc36c712a79f481eed42b420adb4d7d957df9b875L68-R72) [[2]](diffhunk://#diff-b200d6c69e1b94bb7f3dedbf2fb16dfe28e5a96eb203482841fccee2e0b52a95L43-R48) [[3]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L48-R48) [[4]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L63-R70)

**Documentation and analysis notebook updates:**

* The analysis notebook (`docs/analysis-highlights.ipynb`) has been refactored to use polars for all data loading and manipulation, including examples, feature engineering, and plotting. This includes replacing pandas-specific methods with polars equivalents and adjusting code cells for compatibility. [[1]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL61-R69) [[2]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL164-R166) [[3]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL446-R463) [[4]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL514-R586) [[5]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL566-R647) [[6]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR770-R809) [[7]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL706-R837)

**Dependency updates:**

* The `pyproject.toml` file has been updated to add dependencies required for polars data handling and Excel file support (fastexcel, xlsxwriter). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R26) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R43)

**Minor improvements and code clarity:**

* Several notebook cells have been reorganized for better readability and step-by-step execution, including displaying intermediate results and separating transformations. [[1]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR185-R193) [[2]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL240-R251) [[3]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL252-R261) [[4]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL268-R277) [[5]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR320-R348) [[6]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR697-R714)

**References:**  
[[1]](diffhunk://#diff-29e55893b5773fcc477d3cbcf2c45d45e8952b11ea45b2257d48a3c0d02c7e98L4-L7) [[2]](diffhunk://#diff-20fd3e4c369751890e8245aac2e410c6df04e68ead440877e209adb69458bc3fL4-R4) [[3]](diffhunk://#diff-20fd3e4c369751890e8245aac2e410c6df04e68ead440877e209adb69458bc3fL23-R27) [[4]](diffhunk://#diff-38f666ce9ccc6027ff58223dc36c712a79f481eed42b420adb4d7d957df9b875L5-R5) [[5]](diffhunk://#diff-38f666ce9ccc6027ff58223dc36c712a79f481eed42b420adb4d7d957df9b875L68-R72) [[6]](diffhunk://#diff-b200d6c69e1b94bb7f3dedbf2fb16dfe28e5a96eb203482841fccee2e0b52a95L5-R5) [[7]](diffhunk://#diff-b200d6c69e1b94bb7f3dedbf2fb16dfe28e5a96eb203482841fccee2e0b52a95L43-R48) [[8]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L5-R5) [[9]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L48-R48) [[10]](diffhunk://#diff-1cf0d8a8761127488867758161c662dbb12b66f4bc79499e8d33ea6ce032c356L63-R70) [[11]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL61-R69) [[12]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL164-R166) [[13]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR185-R193) [[14]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL240-R251) [[15]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL252-R261) [[16]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL268-R277) [[17]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR320-R348) [[18]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL446-R463) [[19]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL466-R554) [[20]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL514-R586) [[21]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL523-R595) [[22]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR612-R620) [[23]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL566-R647) [[24]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR697-R714) [[25]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdR770-R809) [[26]](diffhunk://#diff-75e400ca270de1f5023b083f8271eb44780a91c187d2700b5c408f6f57520bcdL706-R837) [[27]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R26) [[28]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R43)