### PR TITLE
chore: factored out some additional arguments for re-use

### DIFF
--- a/src/bundestag/cli/download.py
+++ b/src/bundestag/cli/download.py
@@ -3,7 +3,12 @@ import logging
 import typer
 
 import bundestag.paths as paths
-from bundestag.cli.utils import OPTION_DRY
+from bundestag.cli.utils import (
+    ARGUMENT_LEGISLATURE_ID,
+    OPTION_DATA_PATH,
+    OPTION_DRY,
+    OPTION_Y,
+)
 from bundestag.data.download.abgeordnetenwatch.download import (
     run as download_abgeordnetenwatch,
 )
@@ -18,12 +23,9 @@ app = typer.Typer()
 
 @app.command(help="Download data from abgeordnetenwatch.")
 def abgeordnetenwatch(
-    legislature_id: int = typer.Argument(
-        111,
-        help="Bundestag legislature id value, see https://www.abgeordnetenwatch.de/bundestag -> Button 'Open Data'",
-    ),
+    legislature_id: int = ARGUMENT_LEGISLATURE_ID,
     dry: bool = OPTION_DRY,
-    data_path: str = typer.Option("data", help="Root dir for data storage"),
+    data_path: str = OPTION_DATA_PATH,
     max_mandates: int = typer.Option(
         999,
         help="Max number of mandates to download (abgeordnetenwatch specific)",
@@ -32,10 +34,7 @@ def abgeordnetenwatch(
         999,
         help="Max number of polls to download (abgeordnetenwatch specific)",
     ),
-    y: bool = typer.Option(
-        default=False,
-        help="Assume yes to all prompts and run non-interactively.",
-    ),
+    y: bool = OPTION_Y,
 ):
     _paths = paths.get_paths(data_path)
 
@@ -52,14 +51,11 @@ def abgeordnetenwatch(
 @app.command(help="Download data from the bundestag.")
 def bundestag(
     dry: bool = OPTION_DRY,
-    data_path: str = typer.Option("data", help="Root dir for data storage"),
+    data_path: str = OPTION_DATA_PATH,
     nmax: int = typer.Option(
         None, help="Max number of sheets to download (bundestag_sheet specific)"
     ),
-    y: bool = typer.Option(
-        default=False,
-        help="Assume yes to all prompts and run non-interactively.",
-    ),
+    y: bool = OPTION_Y,
     do_create_xlsx_uris_json: bool = typer.Option(
         False,
         help="bundestag_sheet specific parameter. If passed then a new xlsx_uris.json will be created from https://www.bundestag.de/parlament/plenum/abstimmung/liste.",
@@ -86,11 +82,8 @@ def bundestag(
 @app.command(help="Download data from huggingface.")
 def huggingface(
     dry: bool = OPTION_DRY,
-    data_path: str = typer.Option("data", help="Root dir for data storage"),
-    y: bool = typer.Option(
-        default=False,
-        help="Assume yes to all prompts and run non-interactively.",
-    ),
+    data_path: str = OPTION_DATA_PATH,
+    y: bool = OPTION_Y,
 ):
     _paths = paths.get_paths(data_path)
 

--- a/src/bundestag/cli/transform.py
+++ b/src/bundestag/cli/transform.py
@@ -3,7 +3,7 @@ import logging
 import typer
 
 import bundestag.paths as paths
-from bundestag.cli.utils import OPTION_DRY
+from bundestag.cli.utils import ARGUMENT_LEGISLATURE_ID, OPTION_DATA_PATH, OPTION_DRY
 from bundestag.data.transform.abgeordnetenwatch.transform import (
     run as _transform_abgeordnetenwatch,
 )
@@ -18,7 +18,7 @@ app = typer.Typer()
 @app.command(help="Transform bundestag sheet data.")
 def bundestag_sheets(
     dry: bool = OPTION_DRY,
-    data_path: str = typer.Argument("data", help="Root dir for data storage"),
+    data_path: str = OPTION_DATA_PATH,
     sheet_source: SheetsSource = typer.Option(
         SheetsSource.json_file.value,
         help=f"bundestag_sheet specific parameter. Switch between xlsx uri sources. Options: {[k.value for k in SheetsSource]}",
@@ -37,12 +37,9 @@ def bundestag_sheets(
 
 @app.command(help="Transform abgeordnetenwatch data.")
 def abgeordnetenwatch_data(
-    legislature_id: int = typer.Argument(
-        111,
-        help="Bundestag legislature id value, see https://www.abgeordnetenwatch.de/bundestag -> Button 'Open Data'",
-    ),
+    legislature_id: int = ARGUMENT_LEGISLATURE_ID,
     dry: bool = OPTION_DRY,
-    data_path: str = typer.Argument("data", help="Root dir for data storage"),
+    data_path: str = OPTION_DATA_PATH,
 ):
     _paths = paths.get_paths(data_path)
 

--- a/src/bundestag/cli/utils.py
+++ b/src/bundestag/cli/utils.py
@@ -1,3 +1,12 @@
 import typer
 
 OPTION_DRY = typer.Option(False, help="Dry or not")
+OPTION_DATA_PATH = typer.Option("data", help="Root dir for data storage")
+ARGUMENT_LEGISLATURE_ID = typer.Argument(
+    111,
+    help="Bundestag legislature id value, see https://www.abgeordnetenwatch.de/bundestag -> Button 'Open Data'",
+)
+OPTION_Y = typer.Option(
+    default=False,
+    help="Assume yes to all prompts and run non-interactively.",
+)


### PR DESCRIPTION
This pull request refactors the CLI argument and option handling in the `download.py` and `transform.py` modules to improve consistency and reduce duplication. The main change is the centralization of commonly used Typer options and arguments into the `utils.py` file, which are then reused across CLI commands.

**Refactoring and centralization of CLI options/arguments:**

* Added shared Typer option and argument definitions (`OPTION_DATA_PATH`, `ARGUMENT_LEGISLATURE_ID`, `OPTION_Y`) to `src/bundestag/cli/utils.py` for reuse across CLI commands.
* Updated `src/bundestag/cli/download.py` and `src/bundestag/cli/transform.py` to use the centralized options/arguments from `utils.py`, replacing inline definitions for `data_path`, `legislature_id`, and `y` parameters. [[1]](diffhunk://#diff-f7db861e570a5bf20802bf5cf899002d8d8b23d515038ca7c9d24a173a466b94L6-R11) [[2]](diffhunk://#diff-3c101a46c34a7f41c2dec3b2b9b7c977c52e3961a46ed14488f920d3a2076364L6-R6)
* Simplified CLI command signatures in `download.py` and `transform.py` by referencing the shared constants, improving maintainability and consistency. [[1]](diffhunk://#diff-f7db861e570a5bf20802bf5cf899002d8d8b23d515038ca7c9d24a173a466b94L21-R28) [[2]](diffhunk://#diff-f7db861e570a5bf20802bf5cf899002d8d8b23d515038ca7c9d24a173a466b94L35-R37) [[3]](diffhunk://#diff-f7db861e570a5bf20802bf5cf899002d8d8b23d515038ca7c9d24a173a466b94L55-R58) [[4]](diffhunk://#diff-f7db861e570a5bf20802bf5cf899002d8d8b23d515038ca7c9d24a173a466b94L89-R86) [[5]](diffhunk://#diff-3c101a46c34a7f41c2dec3b2b9b7c977c52e3961a46ed14488f920d3a2076364L21-R21) [[6]](diffhunk://#diff-3c101a46c34a7f41c2dec3b2b9b7c977c52e3961a46ed14488f920d3a2076364L40-R42)